### PR TITLE
Fix README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ Skills for Claude Code that teach it to use modern terminal tools.
 
 ## Quick Start
 
-Add this marketplace to Claude Code to access all skills:
+In Claude Code, run:
 
 ```
-https://github.com/yzavyas/claude-1337
+/plugin marketplace add https://github.com/yzavyas/claude-1337
 ```
 
-Claude will automatically detect and use elite tools (or offer to install them).
+That's it! Claude will automatically detect and use elite tools (or offer to install them).
 
 ## What's Included
 


### PR DESCRIPTION
## Summary

README had vague instructions that didn't tell users how to actually install the marketplace.

**Before:**
```
Add this marketplace to Claude Code to access all skills:
https://github.com/yzavyas/claude-1337
```

**After:**
```
In Claude Code, run:
/plugin marketplace add https://github.com/yzavyas/claude-1337
```

Now users know the exact command to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)