### PR TITLE
docs: clarify knowledge pipeline - learning from domain experts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # claude-1337
 
-Skills for Claude Code built by researching what production teams actually use, then distilling it into decision frameworks instead of tutorials.
+Skills for Claude Code built by studying domain experts, production codebases, and reputable technical sources — then distilling into decision frameworks.
 
 ## Install
 
@@ -14,12 +14,12 @@ See [docs/](docs/).
 
 ## How these were built
 
-1. Research what tools/patterns ship in production (not just GitHub stars)
-2. Triage: cut anything Claude already knows, keep the non-obvious stuff
-3. Format as decision tables, not prose explanations
-4. Split into SKILL.md (always loaded) and references/ (loaded when needed)
+1. **Learn** from domain experts, core maintainers, and reputable technical blogs
+2. **Validate** against production codebases — what actually ships, not just what's popular
+3. **Distill** — cut what Claude already knows, keep non-obvious decisions and gotchas
+4. **Format** as decision tables, not prose explanations
 
-The methodology is documented in the `1337-skill-creator` skill.
+The full methodology is documented in `1337-skill-creator`.
 
 ## Contributing
 

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -36,6 +36,7 @@ import Base from '../layouts/Base.astro';
   <h2>philosophy</h2>
 
   <ul>
+    <li><strong>learn from masters</strong> — domain experts, maintainers, reputable blogs</li>
     <li><strong>pick winners</strong> — "use tokio" not "options include tokio, async-std, smol"</li>
     <li><strong>evidence over stars</strong> — what ripgrep, servo, cloudflare actually use</li>
     <li><strong>skip training knowledge</strong> — only add what claude doesn't know</li>


### PR DESCRIPTION
## Summary
- Rewrite README to emphasize learning from domain experts, maintainers, reputable blogs
- Add "learn from masters" as first philosophy bullet in docs index
- Better reflects actual methodology documented in skill-process.md

## Changes
- **README.md**: Updated opening line and "How these were built" section
- **docs/index.astro**: Added "learn from masters" philosophy point

## Test plan
- [x] README accurately reflects knowledge pipeline
- [x] Docs site philosophy section updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)